### PR TITLE
对页面进行两处优化

### DIFF
--- a/src/app/article/article-show/article-show.component.ts
+++ b/src/app/article/article-show/article-show.component.ts
@@ -18,6 +18,10 @@ export class ArticleShowComponent implements OnInit {
   ngOnInit() {
     this.route.paramMap.subscribe((params) => {
       this.article = findArticleById(params.get('id'));
+
+      // 让文章重新滚动至标题处
+      // 72 为导航栏高度（64）与下边距（8）的和
+      document.documentElement.scrollTop = 72;
     });
   }
 

--- a/src/app/shared/outline/outline.service.ts
+++ b/src/app/shared/outline/outline.service.ts
@@ -99,16 +99,26 @@ export class OutlineService implements OnDestroy {
   }
 
   private findActiveItem(): OutlineItem {
-    const insideItems = this.items.filter(it => {
+
+    // 找到在页面之外的下一个标题序号
+    const nextInsideItemIndex = this.items.findIndex(it => {
       const box = it.element.getBoundingClientRect();
       return box.top >= 0;
     });
-    if (!insideItems.length) {
-      return this.items[this.items.length - 1];
+
+    switch (nextInsideItemIndex) {
+      // 页面在头部
+      case 0:
+        return this.items[0];
+
+      // 页面在尾部，已经掠过了所有的标题
+      case -1:
+        return this.items[this.items.length - 1];
+
+      // 其他正常情况
+      default:
+        return this.items[nextInsideItemIndex - 1];
     }
-    const sortedItems = insideItems
-      .sort((v1, v2) => v1.element.scrollTop - v2.element.scrollTop);
-    return sortedItems[0];
   }
 }
 


### PR DESCRIPTION
博主的文章写得很好，受益匪浅，但在页面展示上有两个小细节值得改进一下

1. 当点击左边的文章目录切换文章时，右侧的浏览页仍然保持上一篇文章的滚动位置，需要重新滚动到顶部才能开始阅读这一篇。

2. 页面最右侧的小标题高亮，应该是「当前页面最上方文字所在的**当前**小标题」，而不是「当前页面最上文字所在的**下一个**小标题」，如果页面在最上方（即没有命中任何一个小标题），则高亮第一个小标题（或者也可以不高亮任何标题，但需修改的逻辑更加复杂）